### PR TITLE
Fix trailing comma in buttery-taskbar.json to resolve JSON parsing error

### DIFF
--- a/bucket/buttery-taskbar.json
+++ b/bucket/buttery-taskbar.json
@@ -8,7 +8,7 @@
 	"bin": "buttery-taskbar.exe",
 	"checkver": {
 		"url": "https://raw.githubusercontent.com/CrypticButter/ScoopBucket/master/versions.txt",
-		"regex": "^buttery_taskbar_latest_version\\s+([\\d.]+)$",
+		"regex": "^buttery_taskbar_latest_version\\s+([\\d.]+)$"
 	},
 	"autoupdate": {
 		"url": "https://github.com/LuisThiamNye/ButteryTaskbar2/releases/download/$version/buttery-taskbar.exe"


### PR DESCRIPTION
This PR fixes issue #1 by removing the trailing comma in `buttery-taskbar.json`. This resolves the JSON parsing error and ensures the file can be properly resolved by Scoop.